### PR TITLE
Attach services to swag network and update reverse proxy targets

### DIFF
--- a/HA/docker-compose.yml
+++ b/HA/docker-compose.yml
@@ -45,9 +45,9 @@ services:
       - ./config/zigbee2mqtt:/app/data
     devices:
       - ${ZIGBEE_ADAPTOR_PATH}:/dev/ttyUSB0
-    ports:
-      # frontend, in zigbee's configuration.yaml
-      - "8099:8099"
+    networks:
+      - default
+      - swag
   # node-red:
   #   container_name: node-red
   #   image: nodered/node-red:latest
@@ -70,3 +70,6 @@ networks:
       config:
         - subnet: "10.13.90.0/24"
           gateway: "10.13.90.1" #optional
+  swag:
+    external: true
+    name: swag

--- a/media/docker-compose.yml
+++ b/media/docker-compose.yml
@@ -14,9 +14,10 @@ services:
     ports:
       - 51413:51413
       - 51413:51413/udp
-      - 9091:9091 # transmission
-      - 9696:9696 # prowlarr
     restart: unless-stopped
+    networks:
+      - default
+      - swag
 
   # Torrent client
   transmission:
@@ -81,12 +82,13 @@ services:
       - ./config/sonarr:/config
       - ${TV}:/tv
       - ${DOWNLOADS}:/downloads
-    ports:
-      - 8989:8989
     depends_on:
       - prowlarr
       - transmission
     restart: unless-stopped
+    networks:
+      - default
+      - swag
 
   # Movie library manager
   radaar:
@@ -103,12 +105,13 @@ services:
       - ./config/radarr:/config
       - ${MOVIES}:/movies
       - ${DOWNLOADS}:/downloads
-    ports:
-      - 7878:7878
     depends_on:
       - prowlarr
       - transmission
     restart: unless-stopped
+    networks:
+      - default
+      - swag
 
   # Subtitles downloader
   bazarr:
@@ -124,9 +127,10 @@ services:
       - ./config/bazarr:/config
       - ${MOVIES}:/movies #optional
       - ${TV}:/tv #optional
-    ports:
-      - 6767:6767
     restart: unless-stopped
+    networks:
+      - default
+      - swag
 
   # Media server, stream content
   plex:
@@ -155,9 +159,10 @@ services:
       - TZ=${TZ}
     volumes:
       - ./config/overseer:/config
-    ports:
-      - 5055:5055
     restart: unless-stopped
+    networks:
+      - default
+      - swag
 
   # Front end for Calibre and sync with Kobo e-reader
   # calibre-web:
@@ -187,10 +192,9 @@ services:
       - ${LIBRARY}:/calibre-library
       # This is an ingest dir, NOT a library one. Anything added here will be automatically added to your library according to the settings you have configured in CWA Settings page. All files placed here are REMOVED AFTER PROCESSING
       - ${BOOK_INGEST}:/cwa-book-ingest
-
-    ports:
-      # Change the first number to change the port you want to access the Web UI, not the second
-      - 8083:8083
+    networks:
+      - default
+      - swag
     restart: unless-stopped
 
   readarr:
@@ -204,9 +208,10 @@ services:
       - ./config/readarr:/config
       - ${LIBRARY}:/books #optional
       - ${DOWNLOADS}:/downloads #optional
-    ports:
-      - 8787:8787
     restart: unless-stopped
+    networks:
+      - default
+      - swag
 
   syncthing:
     image: syncthing/syncthing
@@ -217,13 +222,15 @@ services:
       - PGID=${PGID}
       - TZ=${TZ}
     ports:
-      - "8384:8384"      # Web UI
       - "22000:22000/tcp"  # Sync traffic
       - "22000:22000/udp"
       - "21027:21027/udp"  # Discovery
     volumes:
       - ./config/syncthing:/var/syncthing/config
       - ${SAVES}:/var/syncthing/data  # Change this to your media storage path
+    networks:
+      - default
+      - swag
 
 
   flaresolverr:
@@ -249,3 +256,6 @@ networks:
       config:
         - subnet: "10.13.92.0/24"
           gateway: "10.13.92.1" #optional
+  swag:
+    external: true
+    name: swag

--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -2,12 +2,13 @@ services:
   uptime-kuma:
     image: louislam/uptime-kuma
     container_name: uptime-kuma
-    ports:
-      - "3001:3001"
     volumes:
       - ./data/uptime-kuma:/app/data
       - /var/run/docker.sock:/var/run/docker.sock
     restart: always
+    networks:
+      - default
+      - swag
 
   prometheus:
     image: prom/prometheus
@@ -39,8 +40,6 @@ services:
     image: grafana/grafana
     container_name: grafana
     user: "1000"
-    ports:
-      - "3000:3000"
     environment:
       - PUID=1000
       - PGID=1000
@@ -49,6 +48,9 @@ services:
     volumes:
       - ./data/grafana:/var/lib/grafana
     restart: unless-stopped
+    networks:
+      - default
+      - swag
 
   cadvisor:
     image: gcr.io/cadvisor/cadvisor
@@ -78,7 +80,9 @@ services:
     container_name: glances
     restart: unless-stopped
     pid: host
-    network_mode: host
+    networks:
+      - default
+      - swag
     environment:
       GLANCES_OPT: "-w --disable-check-update"
       TZ: ${TZ}
@@ -86,3 +90,10 @@ services:
       - /:/host:ro
       - /mnt/media:/mnt/media:ro
       - /var/run/docker.sock:/var/run/docker.sock:ro
+
+networks:
+  default:
+    name: monitoring_default
+  swag:
+    external: true
+    name: swag

--- a/tools/config/swag/nginx/proxy-confs/_all.subdomain.conf
+++ b/tools/config/swag/nginx/proxy-confs/_all.subdomain.conf
@@ -33,8 +33,8 @@ server {
 
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
-        set $upstream_app 10.13.89.90;
-        set $upstream_port 8380;
+        set $upstream_app adguard;
+        set $upstream_port 80;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
@@ -44,8 +44,8 @@ server {
         include /config/nginx/snippets/authelia/authrequest.conf;
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
-        set $upstream_app 10.13.89.90;
-        set $upstream_port 8380;
+        set $upstream_app adguard;
+        set $upstream_port 80;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
@@ -57,8 +57,8 @@ server {
         # see https://github.com/AdguardTeam/AdGuardHome/wiki/Configuration#configuration-file
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
-        set $upstream_app 10.13.89.90;
-        set $upstream_port 8380;
+        set $upstream_app adguard;
+        set $upstream_port 80;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
@@ -92,7 +92,7 @@ server {
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
         set $upstream_app authelia;
-        set $upstream_port 9092;
+        set $upstream_port 9091;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
@@ -104,7 +104,7 @@ server {
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
         set $upstream_app authelia;
-        set $upstream_port 9092;
+        set $upstream_port 9091;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
@@ -147,7 +147,7 @@ server {
 
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
-        set $upstream_app 10.13.89.90;
+        set $upstream_app bazarr;
         set $upstream_port 6767;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
@@ -158,7 +158,7 @@ server {
         include /config/nginx/snippets/authelia/authrequest.conf;
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
-        set $upstream_app 10.13.89.90;
+        set $upstream_app bazarr;
         set $upstream_port 6767;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
@@ -204,7 +204,7 @@ server {
 
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
-        set $upstream_app 10.13.89.90;
+        set $upstream_app calibre;
         set $upstream_port 8080;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
@@ -230,7 +230,7 @@ server {
 
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
-        set $upstream_app 10.13.89.90;
+        set $upstream_app calibre;
         set $upstream_port 8081;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
@@ -278,7 +278,7 @@ server {
 
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
-        set $upstream_app 10.13.89.90;
+        set $upstream_app calibre-web-automated;
         set $upstream_port 8083;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
@@ -293,7 +293,7 @@ server {
     location /opds/ {
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
-        set $upstream_app 10.13.89.90;
+        set $upstream_app calibre-web-automated;
         set $upstream_port 8083;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
@@ -304,7 +304,7 @@ server {
     # location /kosync/ {
     #     include /config/nginx/proxy.conf;
     #     include /config/nginx/resolver.conf;
-    #     set $upstream_app 10.13.89.90;
+    #     set $upstream_app calibre-web-automated;
     #     set $upstream_port 8083;
     #     set $upstream_proto http;
     #     proxy_pass $upstream_proto://$upstream_app:$upstream_port;
@@ -346,7 +346,7 @@ server {
 
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
-        set $upstream_app 10.13.89.90;
+        set $upstream_app code-server;
         set $upstream_port 8443;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
@@ -389,7 +389,7 @@ server {
 
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
-        set $upstream_app 10.13.89.90;
+        set $upstream_app duplicati;
         set $upstream_port 8200;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
@@ -432,7 +432,7 @@ server {
 
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
-        set $upstream_app 10.13.89.90;
+        set $upstream_app glances;
         set $upstream_port 61208;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
@@ -475,8 +475,8 @@ server {
 
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
-        set $upstream_app 10.13.89.90;
-        set $upstream_port 8002;
+        set $upstream_app homepage;
+        set $upstream_port 3000;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
@@ -528,7 +528,7 @@ server {
 
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
-        set $upstream_app 10.13.89.90;
+        set $upstream_app home-assistant;
         set $upstream_port 8123;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
@@ -539,7 +539,7 @@ server {
         include /config/nginx/snippets/authelia/authrequest.conf;
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
-        set $upstream_app 10.13.89.90;
+        set $upstream_app home-assistant;
         set $upstream_port 8123;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
@@ -581,7 +581,7 @@ server {
 
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
-        set $upstream_app 10.13.89.90;
+        set $upstream_app overseerr;
         set $upstream_port 5055;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
@@ -593,8 +593,8 @@ server {
 ## Version 2022/09/08
 # make sure that your dns has a cname set for plex
 # if plex is running in bridge mode and the container is named "plex", the below config should work as is
-# if not, replace the line "set $upstream_app plex;" with "set $upstream_app <containername>;"
-# or "set $upstream_app <HOSTIP>;" for host mode, HOSTIP being the IP address of plex
+# if not, replace the line "set $upstream_app plex;" with "set $upstream_app plex;"
+# or "set $upstream_app plex;" for host mode, HOSTIP being the IP address of plex
 # in plex server settings, under network, fill in "Custom server access URLs" with your domain (ie. "https://plex.yourdomain.url:443")
 
 server {
@@ -630,7 +630,7 @@ server {
 
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
-        set $upstream_app 10.13.89.90;
+        set $upstream_app plex;
         set $upstream_port 32400;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
@@ -685,7 +685,7 @@ server {
 
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
-        set $upstream_app 10.13.89.90;
+        set $upstream_app portainer;
         set $upstream_port 9000;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
@@ -707,7 +707,7 @@ server {
 
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
-        set $upstream_app 10.13.89.90;
+        set $upstream_app portainer;
         set $upstream_port 9000;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
@@ -751,7 +751,7 @@ server {
 
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
-        set $upstream_app 10.13.89.90;
+        set $upstream_app nordlynx;
         set $upstream_port 9696;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
@@ -761,7 +761,7 @@ server {
         include /config/nginx/snippets/authelia/authrequest.conf;
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
-        set $upstream_app 10.13.89.90;
+        set $upstream_app nordlynx;
         set $upstream_port 9696;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
@@ -803,7 +803,7 @@ server {
 
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
-        set $upstream_app 10.13.89.90;
+        set $upstream_app radarr;
         set $upstream_port 7878;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
@@ -814,7 +814,7 @@ server {
         include /config/nginx/snippets/authelia/authrequest.conf;
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
-        set $upstream_app 10.13.89.90;
+        set $upstream_app radarr;
         set $upstream_port 7878;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
@@ -857,7 +857,7 @@ server {
 
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
-        set $upstream_app 10.13.89.90;
+        set $upstream_app sonarr;
         set $upstream_port 8989;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
@@ -868,7 +868,7 @@ server {
         include /config/nginx/snippets/authelia/authrequest.conf;
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
-        set $upstream_app 10.13.89.90;
+        set $upstream_app sonarr;
         set $upstream_port 8989;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
@@ -921,7 +921,7 @@ server {
 
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
-        set $upstream_app 10.13.89.90;
+        set $upstream_app nordlynx;
         set $upstream_port 9091;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
@@ -933,7 +933,7 @@ server {
         include /config/nginx/snippets/authelia/authrequest.conf;
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
-        set $upstream_app 10.13.89.90;
+        set $upstream_app nordlynx;
         set $upstream_port 9091;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
@@ -976,7 +976,7 @@ server {
 
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
-        set $upstream_app 10.13.89.90;
+        set $upstream_app zigbee2mqtt;
         set $upstream_port 8099;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
@@ -1023,7 +1023,7 @@ server {
 
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
-        set $upstream_app 10.13.89.90;
+        set $upstream_app uptime-kuma;
         set $upstream_port 3001;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
@@ -1071,7 +1071,7 @@ server {
 
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
-        set $upstream_app 10.13.89.90;
+        set $upstream_app grafana;
         set $upstream_port 3000;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
@@ -1084,7 +1084,7 @@ server {
     location ~ (/grafana)?/api {
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
-        set $upstream_app 10.13.89.90;
+        set $upstream_app grafana;
         set $upstream_port 3000;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
@@ -1137,7 +1137,7 @@ server {
 
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
-        set $upstream_app 10.13.89.90;
+        set $upstream_app syncthing;
         set $upstream_port 8384;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
@@ -1148,7 +1148,7 @@ server {
     location ~ (/syncthing)?/rest {
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
-        set $upstream_app 10.13.89.90;
+        set $upstream_app syncthing;
         set $upstream_port 8384;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
@@ -1156,8 +1156,6 @@ server {
         proxy_hide_header Authorization;
     }
 }
-
-
 
 
 

--- a/tools/docker-compose.yml
+++ b/tools/docker-compose.yml
@@ -11,8 +11,9 @@ services:
       - PGID=${PGID}
       - TZ=${TZ}
       - HOMEPAGE_ALLOWED_HOSTS=home.antoineglacet.com
-    ports:
-      - 8002:3000
+    networks:
+      - default
+      - swag
 
   # refresh dynamic IP to cloudflare DNS
   ddclient:
@@ -67,13 +68,12 @@ services:
       - 53:53/udp
       - 67:67/udp
       - 853:853/tcp
-      - 8380:80/tcp
-      - 8300:3000/tcp
-      - 444:443/tcp
-      - 444:443/udp
     depends_on:
       - swag
     restart: unless-stopped
+    networks:
+      - default
+      - swag
 
   # Contaiers management UI
   portainer-ce:
@@ -88,9 +88,10 @@ services:
       - ./config/portainer:/data
     ports:
       - 8000:8000 # Agent
-      - 9443:9443 # https Web UI  
-      - 9000:9000 # http WebUI
     restart: unless-stopped
+    networks:
+      - default
+      - swag
 
   # backup
   duplicati:
@@ -104,9 +105,10 @@ services:
       - ./config/duplicati:/config
       - ${BACKUP}:/backups
       - ${HOMESERVER}:/source
-    ports:
-      - 8200:8200
     restart: unless-stopped
+    networks:
+      - default
+      - swag
 
   # Reverse DNS, nginx & certificates 
   swag:
@@ -125,6 +127,9 @@ services:
       # - EXTRA_DOMAINS=handbook.kanku.dev
     volumes:
       - ./config/swag:/config
+    extra_hosts:
+      - "home-assistant:host-gateway"
+      - "plex:host-gateway"
     ports:
       - 443:443
       # - 80:80 for http validation only
@@ -133,6 +138,7 @@ services:
       swag:
         ipv4_address: 10.13.88.88
       productivity:
+      default:
 
   # Authentification
   authelia:
@@ -151,8 +157,6 @@ services:
     restart: unless-stopped
     networks:
       - swag
-    ports:
-      - 9092:9091
 
   # Restart containers based on health
   autoheal:


### PR DESCRIPTION
## Summary
- connect SWAG and the tools stack services to the default network, add host-gateway aliases for host-mode apps, and drop redundant UI port bindings
- declare the swag network in the media, monitoring, and HA stacks so proxied services can join it while keeping only the ports needed for torrenting or device discovery
- update the consolidated SWAG proxy configuration to reference container hostnames and native ports (including nordlynx for Transmission and Prowlarr) instead of the old host IP

## Testing
- `docker compose -f tools/docker-compose.yml config` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_b_68d14348f7a48328adc144b8ef06ef07