### PR TITLE
Fix Authelia proxy port usage

### DIFF
--- a/tools/config/authelia/configuration.yml
+++ b/tools/config/authelia/configuration.yml
@@ -11,7 +11,7 @@ jwt_secret: '{{ env "AUTHELIA_JWT_SECRET" }}'
 
 server:
   host: 0.0.0.0
-  port: 9092
+  port: 9091
   path: ""
   buffers:
     read: 4096

--- a/tools/config/swag/nginx/proxy-confs/_all.subdomain.conf
+++ b/tools/config/swag/nginx/proxy-confs/_all.subdomain.conf
@@ -92,7 +92,7 @@ server {
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
         set $upstream_app authelia;
-        set $upstream_port 9092;
+        set $upstream_port 9091;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
@@ -104,7 +104,7 @@ server {
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
         set $upstream_app authelia;
-        set $upstream_port 9092;
+        set $upstream_port 9091;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 

--- a/tools/config/swag/nginx/snippets/authelia/location.conf
+++ b/tools/config/swag/nginx/snippets/authelia/location.conf
@@ -1,4 +1,4 @@
-set $upstream_authelia http://authelia:9092/api/verify;
+set $upstream_authelia http://authelia:9091/api/verify;
 
 ## Virtual endpoint created by nginx to forward auth requests.
 location /authelia {

--- a/tools/docker-compose.yml
+++ b/tools/docker-compose.yml
@@ -151,8 +151,6 @@ services:
     restart: unless-stopped
     networks:
       - swag
-    ports:
-      - 9092:9091
 
   # Restart containers based on health
   autoheal:


### PR DESCRIPTION
## Summary
- point the Authelia subdomain proxy at the container's internal port 9091
- align the shared Authelia nginx snippet and Authelia configuration with the container port
- remove the unused Authelia host port exposure from docker-compose

## Testing
- `docker compose -f tools/docker-compose.yml config` *(fails: docker not available in CI environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d14356a83483288db725eaf4efab78