### PR TITLE
Simplify Authelia SWAG snippets

### DIFF
--- a/tools/config/swag/nginx/snippets/authelia/authrequest.conf
+++ b/tools/config/swag/nginx/snippets/authelia/authrequest.conf
@@ -1,25 +1,15 @@
-## Send a subrequest to Authelia to verify if the user is authenticated and has permission to access the resource.
 auth_request /authelia;
 
-## Set the $target_url variable based on the original request.
-
-## Comment this line if you're using nginx without the http_set_misc module.
-# set_escape_uri $target_url $scheme://$http_host$request_uri;
-
-## Uncomment this line if you're using NGINX without the http_set_misc module.
-set $target_url $scheme://$http_host$request_uri;
-
-## Save the upstream response headers from Authelia to variables.
+auth_request_set $target_url $scheme://$http_host$request_uri;
 auth_request_set $user $upstream_http_remote_user;
 auth_request_set $groups $upstream_http_remote_groups;
 auth_request_set $name $upstream_http_remote_name;
 auth_request_set $email $upstream_http_remote_email;
 
-## Inject the response headers from the variables into the request made to the backend.
 proxy_set_header Remote-User $user;
 proxy_set_header Remote-Groups $groups;
 proxy_set_header Remote-Name $name;
 proxy_set_header Remote-Email $email;
 
-## If the subreqest returns 200 pass to the backend, if the subrequest returns 401 redirect to the portal.
 error_page 401 =302 https://auth.antoineglacet.com/?rd=$target_url;
+

--- a/tools/config/swag/nginx/snippets/authelia/location.conf
+++ b/tools/config/swag/nginx/snippets/authelia/location.conf
@@ -1,36 +1,14 @@
-set $upstream_authelia http://authelia:9091/api/verify;
-
-## Virtual endpoint created by nginx to forward auth requests.
 location /authelia {
-    ## Essential Proxy Configuration
     internal;
-    proxy_pass $upstream_authelia;
-
-    ## Headers
-    ## The headers starting with X-* are required.
+    proxy_pass http://authelia:9091/api/verify;
+    proxy_pass_request_body off;
+    proxy_set_header Content-Length "";
     proxy_set_header X-Original-URL $scheme://$http_host$request_uri;
     proxy_set_header X-Original-Method $request_method;
-    proxy_set_header X-Forwarded-Method $request_method;
     proxy_set_header X-Forwarded-Proto $scheme;
     proxy_set_header X-Forwarded-Host $http_host;
     proxy_set_header X-Forwarded-Uri $request_uri;
-    proxy_set_header X-Forwarded-For $remote_addr;
-    proxy_set_header Content-Length "";
-    proxy_set_header Connection "";
-
-    ## Basic Proxy Configuration
-    proxy_pass_request_body off;
-    proxy_next_upstream error timeout invalid_header http_500 http_502 http_503; # Timeout if the real server is dead
-    proxy_redirect http:// $scheme://;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_http_version 1.1;
-    proxy_cache_bypass $cookie_session;
-    proxy_no_cache $cookie_session;
-    proxy_buffers 4 32k;
-    client_body_buffer_size 128k;
-
-    ## Advanced Proxy Configuration
-    send_timeout 5m;
-    proxy_read_timeout 240;
-    proxy_send_timeout 240;
-    proxy_connect_timeout 240;
 }
+


### PR DESCRIPTION
## Summary
- replace the Authelia location snippet with a minimal proxy_pass configuration
- trim the auth request snippet to only the headers and redirect needed for Authelia

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d15e0d481c8328b2060c95d9126ef5