### PR TITLE
docs: refresh readme for consolidated stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,189 +4,99 @@
 
 ## Stack Landscape
 
-| Stack | Network usage | Why it exists | Key services |
+All services now live in one `docker-compose.yml`. Logical groupings still help keep things organised:
+
+| Area | Network usage | Why it exists | Key services |
 | --- | --- | --- | --- |
-| `HA` | Host LAN for discovery + stack default (Docker-managed) | Smart-home automations via Home Assistant with Zigbee over MQTT. | `home-assistant`, `mqtt`, `zigbee2mqtt` |
-| `media` | Stack default + `homelab_proxy` for HTTP ingress | Media acquisition, library curation, and streaming with a NordVPN egress. | `nordlynx`, `transmission`, `prowlarr`, `sonarr`, `radarr`, `plex`, `overseerr`, `readarr`, `syncthing`, `calibre` |
-| `monitoring` | Stack default + `homelab_proxy` for dashboards | Platform observability and alerting. | `uptime-kuma`, `prometheus`, `grafana`, `cadvisor`, `node_exporter` |
-| `tools` | `homelab_proxy` for ingress + host for `fail2ban` | Edge services, SSO, backups, DNS, and portal. | `swag`, `authelia`, `homepage`, `adguard`, `portainer`, `duplicati`, `ddclient`, `samba`, `autoheal`, `fail2ban` |
+| Smart home & Zigbee | Host LAN for discovery, `homelab` for MQTT, `homelab_proxy` for Zigbee UI | Automations, device telemetry, and Zigbee radio access. | `home-assistant`, `mqtt`, `zigbee2mqtt` |
+| Media acquisition & library | `homelab` for internal traffic, `homelab_proxy` for UIs, host for Plex | VPN-protected downloads, request management, and playback. | `nordlynx`, `transmission`, `prowlarr`, `sonarr`, `radarr`, `bazarr`, `readarr`, `plex`, `overseerr`, `calibre-web-automated` |
+| Monitoring & observability | `homelab` for metrics, `homelab_proxy` for dashboards, host exporters | Metrics, uptime checks, and capacity visibility. | `prometheus`, `grafana`, `uptime-kuma`, `cadvisor`, `glances`, `node_exporter` |
+| Edge & utilities | `homelab` + `homelab_proxy` | Reverse proxy, SSO, DNS, backups, syncing, and helper tools. | `swag`, `authelia`, `homepage`, `adguard`, `portainer`, `duplicati`, `ddclient`, `samba`, `syncthing`, `flaresolverr`, `autoheal` |
 
 ## Repo Layout
 
 ```
 home-server
-├── .env.example          # template for secrets & tuning (copy to .env locally)
-├── README.md             # you are here
+├── docker-compose.yml     # consolidated stack definition
+├── README.md              # you are here
 ├── LICENSE
-├── start-all.sh          # spin up every stack
-├── stop-all.sh           # stop every stack
-├── update-all.sh         # pull + redeploy + prune
-├── pull-all.sh           # pull latest images only
-├── weekly-update.sh      # cron-friendly update orchestrator
-├── HA/
-│   ├── docker-compose.yml
-│   └── config/           # Home Assistant, Mosquitto, Zigbee2MQTT state
-├── media/
-│   ├── docker-compose.yml
-│   └── config/           # Plex, Overseerr, *arrs, Syncthing, Calibre, etc.
-├── monitoring/
-│   ├── docker-compose.yml
-│   └── config/           # Prometheus rules, Grafana data, Kuma state
-└── tools/
-    ├── docker-compose.yml
-    └── config/           # AdGuard, Authelia, SWAG, Portainer, backups
+├── config/
+│   ├── authelia/          # Authelia policies and user template
+│   ├── ddclient/          # Dynamic DNS updater config
+│   ├── homeassistant/     # Home Assistant state & automations
+│   ├── homepage/          # Dashboard definition
+│   ├── mosquitto/         # MQTT broker settings
+│   ├── swag/              # Reverse proxy templates & snippets
+│   └── zigbee2mqtt/       # Zigbee bridge configuration
+├── pull-all.sh            # legacy helper (multi-stack version, kept for ref)
+├── start-all.sh           # legacy helper (update pending)
+├── stop-all.sh            # legacy helper (update pending)
+├── update-all.sh          # legacy helper (update pending)
+└── weekly-update.sh       # legacy helper (update pending)
 ```
 
 > Actual secrets live in `.env` **outside** of Git. Keep your own copy synced with the hardware and never commit it.
 
 ## Operating the Lab
 
+With everything consolidated you can control the stack directly with Docker Compose:
+
 | Action | Command | Notes |
 | --- | --- | --- |
-| Boot everything | `./start-all.sh` | Reads stack order and references `.env` for shared vars. |
-| Stop everything | `./stop-all.sh` | Brings stacks down in reverse order. |
-| Refresh images | `./update-all.sh` | Pulls images, redeploys, and prunes dangling layers. |
-| Pull only | `./pull-all.sh` | Useful before scheduled maintenance windows. |
-| Weekly automation | `./weekly-update.sh` | Wrapper for unattended updates + notifications. |
+| Boot everything | `docker compose --env-file .env up -d` | Creates the `homelab` network automatically and joins `homelab_proxy` if it already exists. |
+| Stop everything | `docker compose --env-file .env down` | Stops containers but preserves volumes. |
+| Refresh images | `docker compose --env-file .env pull` | Grab latest images, then rerun `up -d` to apply. |
+| Prune unused bits | `docker system prune` | Optional tidy-up after successful upgrades. |
+
+Helper scripts in the repo still reference the old multi-stack layout. Update or remove them once everything in production is using the new root compose file.
 
 ### Environment & Secrets
 
-- Copy `.env.example` to `.env` on the host and populate credentials (`PUID`, `PGID`, `TZ`, VPN keys, Cloudflare token, etc.).
-- All compose files expect the `.env` file to sit next to the scripts, so run commands from the repo root.
-- Per-service configuration lives under each stack’s `config/` directory and is bind-mounted back into containers.
+- Maintain a `.env` next to `docker-compose.yml` with UID/GID, timezone, storage paths, VPN keys, Cloudflare token, MQTT credentials, Authelia secrets, and Zigbee adaptor path. (Check the compose file for the full list of expected variables.)
+- Run Compose commands from the repo root so the relative `config/` mounts resolve correctly.
+- Per-service configuration lives under `config/` and is bind-mounted back into containers.
 
 ### Networking Notes
 
-- `homelab_proxy` is the only shared bridge network. `swag`, `authelia`, and any HTTP services exposed through the reverse proxy join it across stacks. It is created automatically when the `tools` stack starts (or manually via `docker network create homelab_proxy`).
-- Each stack otherwise relies on the Docker-managed default network, keeping isolation without hard-coding subnets.
-- NordVPN egress is enforced by `network_mode: service:nordlynx` for Transmission and Prowlarr to keep metadata private.
-- Host-mode workloads (`home-assistant`, `plex`, `fail2ban`, `node_exporter`) need raw LAN access for device discovery and firewalling.
+- `homelab` is the default bridge shared by most containers. Host networking is used only where broadcast discovery or raw sockets are required (`home-assistant`, `plex`, `node_exporter`).
+- `homelab_proxy` carries any HTTP(S) endpoint exposed through SWAG/Authelia. Create it once (`docker network create homelab_proxy`) so services in other compose projects can join.
+- NordVPN egress is enforced by `network_mode: service:nordlynx` for Transmission and Prowlarr, keeping traffic inside the tunnel while still exposing their web UIs via published ports on the VPN container.
 - Internal DNS (`adguard`) and DHCP let the Pi act as the network edge, while `ddclient` updates the public hostname.
 
 ## Network Architecture
 
 ```mermaid
 flowchart LR
-    classDef host fill:#fde2e4,stroke:#b56576,color:#111;
-    classDef vpn fill:#ffe066,stroke:#f3722c,color:#111;
-    classDef monitor fill:#dbe7ff,stroke:#3a0ca3,color:#111;
-    classDef edge fill:#d8f3dc,stroke:#2d6a4f,color:#111;
-    classDef proxy fill:#f6f6f6,stroke:#495057,color:#111;
+    subgraph Host["Raspberry Pi / Docker host"]
+        subgraph HostNet["Host network"]
+            homeassistant["home-assistant"]
+            plex["plex"]
+            nodeexporter["node_exporter"]
+        end
 
-    wan((Internet))
-    lan((Home LAN clients))
-    proxyNet((homelab_proxy))
+        subgraph Homelab["homelab bridge"]
+            mqtt["mqtt + zigbee2mqtt"]
+            media["Transmission / *arrs"]
+            monitoring["Prometheus / Grafana / Kuma / cAdvisor / Glances"]
+            utilities["Homepage / DDClient / Samba / Syncthing / Duplicati / Autoheal"]
+        end
 
-    subgraph HostLAN["Host LAN / Docker Engine"]
-        docker[Docker Engine]
-        homeassistant["home-assistant"]
-        plex["plex"]
-        fail2ban["fail2ban"]
-        nodeexporter["node_exporter"]
-    end
-    class homeassistant,plex,fail2ban,nodeexporter host;
-
-    subgraph Zigbee["HA stack (Docker default)"]
-        mqtt["mqtt"]
-        zigbee2mqtt["zigbee2mqtt"]
+        subgraph ProxyNet["homelab_proxy bridge"]
+            swag["SWAG"]
+            authelia["Authelia"]
+            portals["Grafana / Overseerr / Homepage / Kuma"]
+        end
     end
 
-    subgraph Media["Media stack (Docker default)"]
-        nordlynx["nordlynx (VPN tunnel)"]
-        transmission["transmission"]
-        prowlarr["prowlarr"]
-        sonarr["sonarr"]
-        radarr["radarr"]
-        overseerr["overseerr"]
-        bazarr["bazarr"]
-        readarr["readarr"]
-        syncthing["syncthing"]
-        calibre["calibre-web-automated"]
-    end
-    class nordlynx vpn;
+    internet((Internet)) --> swag
+    swag --> authelia --> portals
+    lan((LAN clients)) --> adguard["AdGuard"]
+    lan --> plex
 
-    subgraph Tools["Tools stack (Docker default)"]
-        homepage["homepage"]
-        adguard["adguard"]
-        portainer["portainer"]
-        duplicati["duplicati"]
-        ddclient["ddclient"]
-        samba["samba"]
-        autoheal["autoheal"]
-        swag["swag"]
-        authelia["authelia"]
-    end
-    class homepage,adguard,portainer,duplicati,ddclient,samba,autoheal edge;
-    class swag,authelia proxy;
-
-    subgraph Monitoring["Monitoring stack (Docker default)"]
-        uptime["uptime-kuma"]
-        prometheus["prometheus"]
-        grafana["grafana"]
-        cadvisor["cadvisor"]
-        glances["glances"]
-    end
-    class uptime,prometheus,grafana,cadvisor,glances monitor;
-
-    proxyNet --- swag
-    proxyNet --- authelia
-    proxyNet --- homepage
-    proxyNet --- adguard
-    proxyNet --- portainer
-    proxyNet --- duplicati
-    proxyNet --- grafana
-    proxyNet --- uptime
-    proxyNet --- glances
-    proxyNet --- overseerr
-    proxyNet --- sonarr
-    proxyNet --- radarr
-    proxyNet --- bazarr
-    proxyNet --- readarr
-    proxyNet --- syncthing
-    proxyNet --- calibre
-    proxyNet --- zigbee2mqtt
-    proxyNet --- nordlynx
-
-    wan --> swag
-    lan --> adguard
-    swag --> authelia
-    authelia --> homepage
-    authelia --> portainer
-    authelia --> grafana
-
-    homepage --> lan
-    portainer --> docker
-    autoheal --> docker
-    duplicati --> backup[(Backup target)]
-    ddclient --> dns[(Cloudflare DNS)]
-    samba --> lan
-
-    homeassistant -- automations --> mqtt
-    zigbee2mqtt -- publishes --> mqtt
-    zigbee2mqtt -. "USB Zigbee stick" .- homeassistant
-
-    docker --> homeassistant
-    docker --> plex
-    docker --> fail2ban
-
-    prometheus --> nodeexporter
-    prometheus --> cadvisor
-    grafana --> prometheus
-    uptime -. monitors .- swag
-    uptime -. monitors .- plex
-
-    nordlynx --> vpnexit((NordVPN POP))
-    transmission -. shares namespace .- nordlynx
-    prowlarr -. shares namespace .- nordlynx
-    sonarr --> transmission
-    radarr --> transmission
-    overseerr --> sonarr
-    overseerr --> radarr
-    bazarr --> sonarr
-    readarr --> transmission
-
-    plex --> lan
-    syncthing --> lan
+    media -. shares namespace .- nordlynx["Nordlynx VPN"]
+    homeassistant --> mqtt
+    zigbee_usb(["USB Zigbee stick"]) -.-> mqtt
+    adguard --> internet
 ```
 
 ### Monitoring & Self-Healing


### PR DESCRIPTION
## Summary
- update the README to reflect the consolidated docker-compose layout and service groupings
- refresh operations guidance and environment notes for the single-stack setup
- replace the network diagram with a simplified view of the current networks

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_b_68d177359448832892b65038d28b411e