### PR TITLE
Update Homepage weather widget coordinates

### DIFF
--- a/config/homepage/widgets.yaml
+++ b/config/homepage/widgets.yaml
@@ -6,8 +6,8 @@
 #       timeStyle: short
 - openmeteo:
     label: Osaka # optional
-    latitude: 50.449684
-    longitude: 30.525026
+    latitude: 34.6937
+    longitude: 135.5023
     units: metric # or imperial
     cache: 5 # Time in minutes to cache API responses, to stay within limits
     format: # optional, Intl.NumberFormat options


### PR DESCRIPTION
## Summary
- correct the Open-Meteo widget coordinates for Osaka on the homepage dashboard

## Testing
- Not run (configuration-only change)


------
https://chatgpt.com/codex/tasks/task_b_68d1f96501108328ba5a5976d05a57fe