### PR TITLE
Sanitize Zigbee2MQTT MQTT credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,8 +10,11 @@ LOCAL_NETWORK=192.168.0.0/16
 # Home Assistant
 # Use homeassistant:stable when running not on Raspberry Pi
 
-# Mosquitto
-MQTT_SERVER=mqtt://localhost:1888
+# Mosquitto / Zigbee2MQTT
+# Containers resolve the broker via Docker DNS at mqtt://mqtt:1883.
+# Provide credentials here (passed to Zigbee2MQTT as ZIGBEE2MQTT_CONFIG_MQTT_*)
+# or manage them with !secret entries in config/zigbee2mqtt/secrets.yaml.
+MQTT_SERVER=mqtt://mqtt:1883
 MQTT_USER=example-user
 MQTT_PASSWORD=example-password
 ZIGBEE_ADAPTOR_PATH=/dev/ttyUSB0

--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,4 @@ config/swag/nginx/dhparams.pem
 !config/homeassistant/themes/*
 !config/mosquitto/mosquitto.conf
 !config/zigbee2mqtt/configuration.yaml
+config/zigbee2mqtt/secrets.yaml

--- a/config/zigbee2mqtt/configuration.yaml
+++ b/config/zigbee2mqtt/configuration.yaml
@@ -2,9 +2,8 @@ homeassistant:
   enabled: true
 mqtt:
   base_topic: zigbee2mqtt
-  server: mqtt://172.17.0.1:1888
-  user: hass
-  password: chevalierblanc
+  # Connection details (server, user, password) are supplied via
+  # environment variables (see docker-compose.yml) or !secret entries.
 serial:
   port: /dev/ttyUSB0
 frontend:


### PR DESCRIPTION
## Summary
- remove committed MQTT broker credentials from the Zigbee2MQTT config and rely on environment variables or secrets instead
- document the mqtt://mqtt:1883 Docker DNS endpoint in the sample environment file
- ensure config/zigbee2mqtt/secrets.yaml stays outside version control for real credentials

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d1f92974c88328ba3f7ba4d9666c22