### PR TITLE
Adjust Authelia logging defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,3 +200,21 @@ flowchart LR
 - Media libraries mount from host paths defined in `.env` (`${MEDIA}`, `${MOVIES}`, `${TV}`, `${DOWNLOADS}`, etc.).
 - `duplicati` targets `${BACKUP}` for encrypted backups; customize retention and destinations in `config/duplicati`.
 - Samba exposes `${DATA}` to Windows clients for simple drag-and-drop access.
+
+### Authelia Logging
+
+- Authelia now defaults to the quieter `info` log level in `config/authelia/configuration.yml`, which is more appropriate for normal operations.
+- When deeper troubleshooting is required, create a short-lived override file to bump logging without touching the tracked configuration:
+
+  ```bash
+  cat <<'EOF' > authelia-debug.override.yml
+  services:
+    authelia:
+      environment:
+        AUTHELIA_LOG_LEVEL: debug
+  EOF
+
+  docker compose -f docker-compose.yml -f authelia-debug.override.yml up -d authelia
+  ```
+
+  Removing the override file and redeploying (`rm authelia-debug.override.yml && docker compose up -d authelia`) drops Authelia back to the baseline `info` level.

--- a/config/authelia/configuration.yml
+++ b/config/authelia/configuration.yml
@@ -24,7 +24,7 @@ server:
     certificate: ""
 
 log:
-  level: debug
+  level: info
   format: json
   file_path: "/config/authelia.log"
   keep_stdout: true


### PR DESCRIPTION
## Summary
- switch Authelia's log level from debug to info for production readiness
- document a temporary override workflow for enabling debug logging via docker compose

## Testing
- ⚠️ `docker compose ps authelia` *(fails: docker command not available in container)*

------
https://chatgpt.com/codex/tasks/task_b_68d1f96bb7588328b2d7d70d3c932b3a