### PR TITLE
Refactor helper scripts to use shared compose helpers

### DIFF
--- a/lib/compose.sh
+++ b/lib/compose.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+# Shared helpers for interacting with the project's Docker Compose stack.
+
+_compose_default_reporter() {
+  echo "$1" >&2
+}
+
+require_compose_stack() {
+  local compose_file="$1"
+  local env_file="$2"
+  local reporter="${3:-_compose_default_reporter}"
+
+  if [[ ! -f "${compose_file}" ]]; then
+    "${reporter}" "Error: docker-compose.yml not found at ${compose_file}"
+    return 1
+  fi
+
+  if [[ ! -f "${env_file}" ]]; then
+    "${reporter}" "Error: .env not found at ${env_file}"
+    return 1
+  fi
+}
+
+find_compose() {
+  if command -v docker >/dev/null 2>&1; then
+    if docker compose version >/dev/null 2>&1; then
+      COMPOSE=(docker compose)
+      return 0
+    fi
+  fi
+
+  if command -v docker-compose >/dev/null 2>&1; then
+    COMPOSE=(docker-compose)
+    return 0
+  fi
+
+  COMPOSE=()
+  return 1
+}
+
+ensure_compose_command() {
+  local reporter="${1:-_compose_default_reporter}"
+
+  if find_compose; then
+    return 0
+  fi
+
+  "${reporter}" "Error: docker compose or docker-compose is required but not installed."
+  return 1
+}

--- a/pull-all.sh
+++ b/pull-all.sh
@@ -1,11 +1,14 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
-# list of all folders to consider
-# Declare an array of string with type
-declare -a StringArray=("HA" "media" "tools")
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMPOSE_FILE="${ROOT_DIR}/docker-compose.yml"
+ENV_FILE="${ROOT_DIR}/.env"
 
-# Loop over folders and reference the env-file
-# Iterate the string array using for loop
-for val in "${StringArray[@]}"; do
-   docker compose --file "$val"/docker-compose.yml --env-file .env pull
-done
+# shellcheck source=lib/compose.sh
+source "${ROOT_DIR}/lib/compose.sh"
+
+require_compose_stack "${COMPOSE_FILE}" "${ENV_FILE}"
+ensure_compose_command
+
+"${COMPOSE[@]}" --env-file "${ENV_FILE}" -f "${COMPOSE_FILE}" pull

--- a/start-all.sh
+++ b/start-all.sh
@@ -1,11 +1,14 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
-# list of all folders to consider
-# Declare an array of string with type
-declare -a StringArray=("tools" "media" "HA" "monitoring")
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMPOSE_FILE="${ROOT_DIR}/docker-compose.yml"
+ENV_FILE="${ROOT_DIR}/.env"
 
-# Loop over folders and reference the env-file
-# Iterate the string array using for loop
-for val in "${StringArray[@]}"; do
-   docker compose --file "$val"/docker-compose.yml --env-file .env up -d --remove-orphans
-done
+# shellcheck source=lib/compose.sh
+source "${ROOT_DIR}/lib/compose.sh"
+
+require_compose_stack "${COMPOSE_FILE}" "${ENV_FILE}"
+ensure_compose_command
+
+"${COMPOSE[@]}" --env-file "${ENV_FILE}" -f "${COMPOSE_FILE}" up -d --remove-orphans

--- a/stop-all.sh
+++ b/stop-all.sh
@@ -1,11 +1,14 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
-# list of all folders to consider
-# Declare an array of string with type
-declare -a StringArray=("HA" "media" "tools" "monitoring")
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMPOSE_FILE="${ROOT_DIR}/docker-compose.yml"
+ENV_FILE="${ROOT_DIR}/.env"
 
-# Loop over folders and reference the env-file
-# Iterate the string array using for loop
-for val in "${StringArray[@]}"; do
-   docker compose --file "$val"/docker-compose.yml --env-file .env down
-done
+# shellcheck source=lib/compose.sh
+source "${ROOT_DIR}/lib/compose.sh"
+
+require_compose_stack "${COMPOSE_FILE}" "${ENV_FILE}"
+ensure_compose_command
+
+"${COMPOSE[@]}" --env-file "${ENV_FILE}" -f "${COMPOSE_FILE}" down

--- a/weekly-update.sh
+++ b/weekly-update.sh
@@ -1,27 +1,60 @@
 #!/usr/bin/env bash
 # file used as root cron for weekly update of whole server
+set -euo pipefail
 
 # home server directory
-HOMESERVER="/home/ubuntu/home-server/"
+HOMESERVER="${HOMESERVER:-/home/ubuntu/home-server}"
+COMPOSE_FILE="${HOMESERVER}/docker-compose.yml"
+ENV_FILE="${HOMESERVER}/.env"
+HELPERS_FILE="${HOMESERVER}/lib/compose.sh"
+LOG_FILE="/var/tmp/cron.logtest"
+SKIP_APT_UPDATES="${SKIP_APT_UPDATES:-0}"
 
-# to record cmd output in log and to ouput for emailing with cron
-log_cmd() {
-   now=$(date)
-   "$@" 2>&1 | awk -v now="$now" '{ printf("[%s]\t%s\n", now, $0) }' | tee -a /var/tmp/cron.logtest
+log_msg() {
+  local now
+  now=$(date)
+  printf '[%s]\t%s\n' "$now" "$*" | tee -a "${LOG_FILE}"
 }
 
+log_cmd() {
+  local now
+  now=$(date)
+  log_msg "$*"
+  "$@" 2>&1 | awk -v now="${now}" '{ printf("[%s]\t%s\n", now, $0) }' | tee -a "${LOG_FILE}"
+}
+
+if [[ ! -d "${HOMESERVER}" ]]; then
+  log_msg "Error: HOMESERVER directory not found at ${HOMESERVER}"
+  exit 1
+fi
+
+if [[ ! -f "${HELPERS_FILE}" ]]; then
+  log_msg "Error: compose helper library not found at ${HELPERS_FILE}"
+  exit 1
+fi
+
+# shellcheck source=/dev/null
+source "${HELPERS_FILE}"
+
+require_compose_stack "${COMPOSE_FILE}" "${ENV_FILE}" log_msg
+ensure_compose_command log_msg
+
 # update and upgrade all packages
-log_cmd sudo apt update -q -y && log_cmd sudo apt upgrade -q -y
+if [[ "${SKIP_APT_UPDATES}" != "1" ]]; then
+  log_cmd sudo apt update -q -y
+  log_cmd sudo apt upgrade -q -y
+else
+  log_msg "Skipping apt package updates (SKIP_APT_UPDATES=${SKIP_APT_UPDATES})"
+fi
 
-# pull and restart all stacks
-declare -a StringArray=("tools" "media" "HA")
-for val in "${StringArray[@]}"; do
-   log_cmd docker compose --file "$HOMESERVER""$val"/docker-compose.yml --env-file "$HOMESERVER".env pull -q
-   log_cmd docker compose --file "$HOMESERVER""$val"/docker-compose.yml --env-file "$HOMESERVER".env up -d
-done
+# pull and restart all services defined in the root compose file
+log_cmd "${COMPOSE[@]}" --env-file "${ENV_FILE}" -f "${COMPOSE_FILE}" pull
+log_cmd "${COMPOSE[@]}" --env-file "${ENV_FILE}" -f "${COMPOSE_FILE}" up -d --remove-orphans
 
-# # prune
-docker system prune -f
+# prune unused resources
+if command -v docker >/dev/null 2>&1; then
+  log_cmd docker system prune -f
+fi
 
 # restart for good measure
 # if [ -f /var/run/reboot-required ]; then


### PR DESCRIPTION
## Summary
- add a shared `lib/compose.sh` to centralize compose command discovery and stack validation
- update the helper scripts to source the shared helpers before executing compose operations
- adjust the weekly cron update script to load the shared helpers via the configurable HOMESERVER path

## Testing
- PATH="${TMPBIN}:$PATH" ./pull-all.sh
- PATH="${TMPBIN}:$PATH" ./start-all.sh
- PATH="${TMPBIN}:$PATH" ./stop-all.sh
- PATH="${TMPBIN}:$PATH" ./update-all.sh
- HOMESERVER="$(pwd)" SKIP_APT_UPDATES=1 PATH="${TMPBIN}:$PATH" ./weekly-update.sh


------
https://chatgpt.com/codex/tasks/task_b_68d1f93b55e883288ccad4d2cd8472db