### PR TITLE
Add AppFlowy Cloud services behind Traefik

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,39 +1,51 @@
-# Common environment
+# ----------------------------
+# COMMON ENVIRONMENT
+# ----------------------------
 TZ=Asia/Tokyo
 PUID=1000
 PGID=1000
 
-# Networking
-# to allow all network ip 192.168.xxx.xxx as local
+# ----------------------------
+# NETWORKING
+# ----------------------------
+# Allow all 192.168.x.x addresses to be treated as local
 LOCAL_NETWORK=192.168.0.0/16
 
-# Reverse proxy / certificates
+# ----------------------------
+# REVERSE PROXY / CERTIFICATES
+# ----------------------------
 TRAEFIK_DOMAIN=antoineglacet.com
 TRAEFIK_ACME_EMAIL=admin@example.com
 TRAEFIK_CLOUDFLARE_TOKEN=change_me_cloudflare_token
+CERT=./config/traefik/certs/antoineglacet.com
 
-# Home Assistant
+# ----------------------------
+# HOME AUTOMATION
+# ----------------------------
 # Use homeassistant:stable when running not on Raspberry Pi
 
-# Mosquitto / Zigbee2MQTT
-# Containers resolve the broker via Docker DNS at mqtt://mqtt:1883.
-# Provide credentials here (passed to Zigbee2MQTT as ZIGBEE2MQTT_CONFIG_MQTT_*)
-# or manage them with !secret entries in config/zigbee2mqtt/secrets.yaml.
+# MQTT broker for Zigbee2MQTT
 MQTT_SERVER=mqtt://mqtt:1883
 MQTT_USER=example-user
 MQTT_PASSWORD=example-password
 ZIGBEE_ADAPTOR_PATH=/dev/ttyUSB0
 
-# Authelia secrets
+# ----------------------------
+# AUTHENTICATION & SECRETS
+# ----------------------------
 AUTHELIA_JWT_SECRET=change_me_jwt_secret
 AUTHELIA_SESSION_SECRET=change_me_session_secret
 AUTHELIA_STORAGE_ENCRYPTION_KEY=change_me_storage_key
 AUTHELIA_SMTP_PASSWORD=change_me_smtp_password
 
-# Dynamic DNS
+# ----------------------------
+# DYNAMIC DNS
+# ----------------------------
 DDCLIENT_CLOUDFLARE_TOKEN=change_me_cloudflare_token
 
-# Directories
+# ----------------------------
+# DIRECTORIES
+# ----------------------------
 DATA=/mnt/data
 BACKUP=/mnt/data/backup
 DOWNLOADS=/mnt/data/downloads
@@ -44,18 +56,82 @@ TV=/mnt/data/media/tv
 LIBRARY=/mnt/data/media/calibre-library
 BOOK_INGEST=/mnt/data/media/book_ingest
 SAVES=/mnt/data/gamesaves
-
 HOMESERVER=/home/username/home-server
 
-# NordVPN
-# Found with command :
+# ----------------------------
+# VPN (NORDVPN)
+# ----------------------------
 # sudo docker run --rm --cap-add=NET_ADMIN -e USER=email \
-# -e PASS=password -e legacy bubuntux/nordvpn:get_private_key
+#   -e PASS=password -e legacy bubuntux/nordvpn:get_private_key
 NORDVPN_PRIVATE_KEY=XXXXXXXXXXXXXXXXXXXXXXXXX
 
-# Samba
+# ----------------------------
+# SAMBA
+# ----------------------------
 SAMBA_USER=example-user
 SAMBA_PASSWORD=example-password
 
-# Cert location
-CERT=./config/traefik/certs/antoineglacet.com
+# ----------------------------
+# APPFLOWY CLOUD
+# ----------------------------
+# Public hostnames & URLs used by AppFlowy services
+APPFLOWY_DOMAIN=appflowy.example.com
+APPFLOWY_PUBLIC_BASE_URL=https://appflowy.example.com
+APPFLOWY_PUBLIC_GOTRUE_URL=https://appflowy.example.com/gotrue
+APPFLOWY_PUBLIC_WS_URL=wss://appflowy.example.com/ws
+APPFLOWY_PUBLIC_MINIO_CONSOLE_URL=https://appflowy.example.com/minio
+APPFLOWY_S3_PRESIGNED_URL_ENDPOINT=https://appflowy.example.com/minio-api
+
+# PostgreSQL configuration
+POSTGRES_HOST=appflowy-postgres
+POSTGRES_PORT=5432
+POSTGRES_USER=appflowy
+POSTGRES_PASSWORD=change_me_appflowy_db_password
+POSTGRES_DB=appflowy
+APPFLOWY_DATABASE_URL=postgres://appflowy:change_me_appflowy_db_password@appflowy-postgres:5432/appflowy
+GOTRUE_DATABASE_URL=postgres://appflowy:change_me_appflowy_db_password@appflowy-postgres:5432/appflowy?search_path=auth
+APPFLOWY_WORKER_DATABASE_URL=postgres://appflowy:change_me_appflowy_db_password@appflowy-postgres:5432/appflowy
+APPFLOWY_WORKER_DATABASE_NAME=appflowy
+
+# Redis configuration
+APPFLOWY_REDIS_URI=redis://appflowy-redis:6379
+APPFLOWY_WORKER_REDIS_URL=redis://appflowy-redis:6379
+
+# Storage (MinIO)
+APPFLOWY_S3_USE_MINIO=true
+APPFLOWY_S3_CREATE_BUCKET=true
+APPFLOWY_S3_MINIO_URL=http://appflowy-minio:9000
+APPFLOWY_S3_ACCESS_KEY=appflowy
+APPFLOWY_S3_SECRET_KEY=change_me_minio_secret
+APPFLOWY_S3_BUCKET=appflowy
+APPFLOWY_S3_REGION=us-east-1
+
+# AppFlowy mailer settings (use real SMTP settings for production)
+APPFLOWY_MAILER_SMTP_HOST=smtp.example.com
+APPFLOWY_MAILER_SMTP_PORT=465
+APPFLOWY_MAILER_SMTP_USERNAME=notifications@example.com
+APPFLOWY_MAILER_SMTP_EMAIL=notifications@example.com
+APPFLOWY_MAILER_SMTP_PASSWORD=change_me_mailer_password
+APPFLOWY_MAILER_SMTP_TLS_KIND=wrapper
+
+# Core AppFlowy configuration
+APPFLOWY_ACCESS_CONTROL=true
+APPFLOWY_DATABASE_MAX_CONNECTIONS=40
+ADMIN_FRONTEND_PATH_PREFIX=/console
+
+# GoTrue authentication service
+GOTRUE_ADMIN_EMAIL=admin@example.com
+GOTRUE_ADMIN_PASSWORD=change_me_admin_password
+GOTRUE_DISABLE_SIGNUP=false
+GOTRUE_JWT_SECRET=change_me_gotrue_jwt_secret
+GOTRUE_JWT_EXP=7200
+GOTRUE_MAILER_AUTOCONFIRM=true
+GOTRUE_RATE_LIMIT_EMAIL_SENT=100
+GOTRUE_MAILER_TEMPLATES_MAGIC_LINK=
+GOTRUE_SMTP_HOST=smtp.example.com
+GOTRUE_SMTP_PORT=465
+GOTRUE_SMTP_USER=notifications@example.com
+GOTRUE_SMTP_PASS=change_me_mailer_password
+GOTRUE_SMTP_ADMIN_EMAIL=admin@example.com
+GOTRUE_SMTP_MAX_FREQUENCY=1ns
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -497,7 +497,259 @@ services:
       - "traefik.http.services.syncthing.loadbalancer.server.port=8384"
 
   # ----------------------------
-  # UTILS
+  # APPFLOWY CLOUD
+  # ----------------------------
+
+  appflowy-postgres:
+    image: pgvector/pgvector:pg16
+    container_name: appflowy-postgres
+    restart: unless-stopped
+    environment:
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRES_DB=${POSTGRES_DB}
+    healthcheck:
+      test: [ "CMD", "pg_isready", "-U", "${POSTGRES_USER}", "-d", "${POSTGRES_DB}" ]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+    volumes:
+      - ./data/appflowy/postgres:/var/lib/postgresql/data
+    networks:
+      - homelab
+
+  appflowy-redis:
+    image: redis:7
+    container_name: appflowy-redis
+    restart: unless-stopped
+    command: [ "redis-server", "--save", "20", "1", "--loglevel", "warning" ]
+    healthcheck:
+      test: [ "CMD", "redis-cli", "ping" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    volumes:
+      - ./data/appflowy/redis:/data
+    networks:
+      - homelab
+
+  appflowy-minio:
+    image: minio/minio
+    container_name: appflowy-minio
+    restart: unless-stopped
+    command: server /data --console-address ":9001"
+    environment:
+      - MINIO_BROWSER_REDIRECT_URL=${APPFLOWY_PUBLIC_MINIO_CONSOLE_URL}
+      - MINIO_ROOT_USER=${APPFLOWY_S3_ACCESS_KEY}
+      - MINIO_ROOT_PASSWORD=${APPFLOWY_S3_SECRET_KEY}
+    volumes:
+      - ./data/appflowy/minio:/data
+    networks:
+      - homelab
+      - homelab_proxy
+    labels:
+      - "traefik.enable=true"
+      - "traefik.docker.network=homelab_proxy"
+      - "traefik.http.routers.appflowy-minio-console.rule=Host(`${APPFLOWY_DOMAIN}`) && PathPrefix(`/minio`)"
+      - "traefik.http.routers.appflowy-minio-console.entrypoints=websecure"
+      - "traefik.http.routers.appflowy-minio-console.tls.certresolver=cloudflare"
+      - "traefik.http.routers.appflowy-minio-console.middlewares=appflowy-strip-minio@docker"
+      - "traefik.http.services.appflowy-minio-console.loadbalancer.server.port=9001"
+      - "traefik.http.routers.appflowy-minio-api.rule=Host(`${APPFLOWY_DOMAIN}`) && PathPrefix(`/minio-api`)"
+      - "traefik.http.routers.appflowy-minio-api.entrypoints=websecure"
+      - "traefik.http.routers.appflowy-minio-api.tls.certresolver=cloudflare"
+      - "traefik.http.routers.appflowy-minio-api.middlewares=appflowy-strip-minio-api@docker,appflowy-minio-internal-host@docker"
+      - "traefik.http.services.appflowy-minio-api.loadbalancer.server.port=9000"
+      - "traefik.http.middlewares.appflowy-strip-minio.stripprefix.prefixes=/minio"
+      - "traefik.http.middlewares.appflowy-strip-minio-api.stripprefix.prefixes=/minio-api"
+      - "traefik.http.middlewares.appflowy-minio-internal-host.headers.customrequestheaders.Host=appflowy-minio:9000"
+
+  appflowy-gotrue:
+    image: appflowyinc/gotrue:${GOTRUE_VERSION:-latest}
+    container_name: appflowy-gotrue
+    restart: unless-stopped
+    depends_on:
+      appflowy-postgres:
+        condition: service_healthy
+    healthcheck:
+      test: [ "CMD", "curl", "--fail", "http://127.0.0.1:9999/health" ]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+    environment:
+      - GOTRUE_ADMIN_EMAIL=${GOTRUE_ADMIN_EMAIL}
+      - GOTRUE_ADMIN_PASSWORD=${GOTRUE_ADMIN_PASSWORD}
+      - GOTRUE_DISABLE_SIGNUP=${GOTRUE_DISABLE_SIGNUP}
+      - GOTRUE_SITE_URL=appflowy-flutter://
+      - GOTRUE_URI_ALLOW_LIST=**
+      - GOTRUE_JWT_SECRET=${GOTRUE_JWT_SECRET}
+      - GOTRUE_JWT_EXP=${GOTRUE_JWT_EXP}
+      - GOTRUE_JWT_ADMIN_GROUP_NAME=supabase_admin
+      - GOTRUE_DB_DRIVER=postgres
+      - API_EXTERNAL_URL=${APPFLOWY_PUBLIC_GOTRUE_URL}
+      - DATABASE_URL=${GOTRUE_DATABASE_URL}
+      - GOTRUE_MAILER_AUTOCONFIRM=${GOTRUE_MAILER_AUTOCONFIRM}
+      - GOTRUE_RATE_LIMIT_EMAIL_SENT=${GOTRUE_RATE_LIMIT_EMAIL_SENT}
+      - GOTRUE_SMTP_HOST=${GOTRUE_SMTP_HOST}
+      - GOTRUE_SMTP_PORT=${GOTRUE_SMTP_PORT}
+      - GOTRUE_SMTP_USER=${GOTRUE_SMTP_USER}
+      - GOTRUE_SMTP_PASS=${GOTRUE_SMTP_PASS}
+      - GOTRUE_MAILER_URLPATHS_CONFIRMATION=/gotrue/verify
+      - GOTRUE_MAILER_URLPATHS_INVITE=/gotrue/verify
+      - GOTRUE_MAILER_URLPATHS_RECOVERY=/gotrue/verify
+      - GOTRUE_MAILER_URLPATHS_EMAIL_CHANGE=/gotrue/verify
+      - GOTRUE_MAILER_TEMPLATES_MAGIC_LINK=${GOTRUE_MAILER_TEMPLATES_MAGIC_LINK}
+      - GOTRUE_SMTP_ADMIN_EMAIL=${GOTRUE_SMTP_ADMIN_EMAIL}
+      - GOTRUE_SMTP_MAX_FREQUENCY=${GOTRUE_SMTP_MAX_FREQUENCY}
+    networks:
+      - homelab
+      - homelab_proxy
+    labels:
+      - "traefik.enable=true"
+      - "traefik.docker.network=homelab_proxy"
+      - "traefik.http.routers.appflowy-gotrue.rule=Host(`${APPFLOWY_DOMAIN}`) && PathPrefix(`/gotrue`)"
+      - "traefik.http.routers.appflowy-gotrue.entrypoints=websecure"
+      - "traefik.http.routers.appflowy-gotrue.tls.certresolver=cloudflare"
+      - "traefik.http.routers.appflowy-gotrue.middlewares=appflowy-strip-gotrue@docker"
+      - "traefik.http.services.appflowy-gotrue.loadbalancer.server.port=9999"
+      - "traefik.http.middlewares.appflowy-strip-gotrue.stripprefix.prefixes=/gotrue"
+
+  appflowy-cloud:
+    image: appflowyinc/appflowy_cloud:${APPFLOWY_CLOUD_VERSION:-latest}
+    container_name: appflowy-cloud
+    restart: unless-stopped
+    depends_on:
+      appflowy-gotrue:
+        condition: service_healthy
+      appflowy-postgres:
+        condition: service_healthy
+      appflowy-redis:
+        condition: service_started
+      appflowy-minio:
+        condition: service_started
+    environment:
+      - RUST_LOG=info
+      - APPFLOWY_ENVIRONMENT=production
+      - APPFLOWY_DATABASE_URL=${APPFLOWY_DATABASE_URL}
+      - APPFLOWY_REDIS_URI=${APPFLOWY_REDIS_URI}
+      - APPFLOWY_GOTRUE_JWT_SECRET=${GOTRUE_JWT_SECRET}
+      - APPFLOWY_GOTRUE_JWT_EXP=${GOTRUE_JWT_EXP}
+      - APPFLOWY_GOTRUE_BASE_URL=${APPFLOWY_PUBLIC_GOTRUE_URL}
+      - APPFLOWY_S3_CREATE_BUCKET=${APPFLOWY_S3_CREATE_BUCKET}
+      - APPFLOWY_S3_USE_MINIO=${APPFLOWY_S3_USE_MINIO}
+      - APPFLOWY_S3_MINIO_URL=${APPFLOWY_S3_MINIO_URL}
+      - APPFLOWY_S3_ACCESS_KEY=${APPFLOWY_S3_ACCESS_KEY}
+      - APPFLOWY_S3_SECRET_KEY=${APPFLOWY_S3_SECRET_KEY}
+      - APPFLOWY_S3_BUCKET=${APPFLOWY_S3_BUCKET}
+      - APPFLOWY_S3_REGION=${APPFLOWY_S3_REGION}
+      - APPFLOWY_S3_PRESIGNED_URL_ENDPOINT=${APPFLOWY_S3_PRESIGNED_URL_ENDPOINT}
+      - APPFLOWY_MAILER_SMTP_HOST=${APPFLOWY_MAILER_SMTP_HOST}
+      - APPFLOWY_MAILER_SMTP_PORT=${APPFLOWY_MAILER_SMTP_PORT}
+      - APPFLOWY_MAILER_SMTP_USERNAME=${APPFLOWY_MAILER_SMTP_USERNAME}
+      - APPFLOWY_MAILER_SMTP_EMAIL=${APPFLOWY_MAILER_SMTP_EMAIL}
+      - APPFLOWY_MAILER_SMTP_PASSWORD=${APPFLOWY_MAILER_SMTP_PASSWORD}
+      - APPFLOWY_MAILER_SMTP_TLS_KIND=${APPFLOWY_MAILER_SMTP_TLS_KIND}
+      - APPFLOWY_ACCESS_CONTROL=${APPFLOWY_ACCESS_CONTROL}
+      - APPFLOWY_DATABASE_MAX_CONNECTIONS=${APPFLOWY_DATABASE_MAX_CONNECTIONS}
+      - APPFLOWY_WEB_URL=${APPFLOWY_PUBLIC_BASE_URL}
+      - APPFLOWY_BASE_URL=${APPFLOWY_PUBLIC_BASE_URL}
+    networks:
+      - homelab
+      - homelab_proxy
+    labels:
+      - "traefik.enable=true"
+      - "traefik.docker.network=homelab_proxy"
+      - "traefik.http.routers.appflowy-api.rule=Host(`${APPFLOWY_DOMAIN}`) && PathPrefix(`/api`)"
+      - "traefik.http.routers.appflowy-api.entrypoints=websecure"
+      - "traefik.http.routers.appflowy-api.tls.certresolver=cloudflare"
+      - "traefik.http.routers.appflowy-api.service=appflowy-cloud"
+      - "traefik.http.routers.appflowy-ws.rule=Host(`${APPFLOWY_DOMAIN}`) && PathPrefix(`/ws`)"
+      - "traefik.http.routers.appflowy-ws.entrypoints=websecure"
+      - "traefik.http.routers.appflowy-ws.tls.certresolver=cloudflare"
+      - "traefik.http.routers.appflowy-ws.service=appflowy-cloud"
+      - "traefik.http.services.appflowy-cloud.loadbalancer.server.port=8000"
+
+  appflowy-worker:
+    image: appflowyinc/appflowy_worker:${APPFLOWY_WORKER_VERSION:-latest}
+    container_name: appflowy-worker
+    restart: unless-stopped
+    depends_on:
+      appflowy-postgres:
+        condition: service_healthy
+      appflowy-redis:
+        condition: service_started
+    environment:
+      - RUST_LOG=info
+      - APPFLOWY_ENVIRONMENT=production
+      - APPFLOWY_WORKER_REDIS_URL=${APPFLOWY_WORKER_REDIS_URL}
+      - APPFLOWY_WORKER_DATABASE_URL=${APPFLOWY_WORKER_DATABASE_URL}
+      - APPFLOWY_WORKER_DATABASE_NAME=${APPFLOWY_WORKER_DATABASE_NAME}
+      - APPFLOWY_WORKER_IMPORT_TICK_INTERVAL=30
+      - APPFLOWY_S3_USE_MINIO=${APPFLOWY_S3_USE_MINIO}
+      - APPFLOWY_S3_MINIO_URL=${APPFLOWY_S3_MINIO_URL}
+      - APPFLOWY_S3_ACCESS_KEY=${APPFLOWY_S3_ACCESS_KEY}
+      - APPFLOWY_S3_SECRET_KEY=${APPFLOWY_S3_SECRET_KEY}
+      - APPFLOWY_S3_BUCKET=${APPFLOWY_S3_BUCKET}
+      - APPFLOWY_S3_REGION=${APPFLOWY_S3_REGION}
+      - APPFLOWY_MAILER_SMTP_HOST=${APPFLOWY_MAILER_SMTP_HOST}
+      - APPFLOWY_MAILER_SMTP_PORT=${APPFLOWY_MAILER_SMTP_PORT}
+      - APPFLOWY_MAILER_SMTP_USERNAME=${APPFLOWY_MAILER_SMTP_USERNAME}
+      - APPFLOWY_MAILER_SMTP_EMAIL=${APPFLOWY_MAILER_SMTP_EMAIL}
+      - APPFLOWY_MAILER_SMTP_PASSWORD=${APPFLOWY_MAILER_SMTP_PASSWORD}
+      - APPFLOWY_MAILER_SMTP_TLS_KIND=${APPFLOWY_MAILER_SMTP_TLS_KIND}
+    networks:
+      - homelab
+
+  appflowy-web:
+    image: appflowyinc/appflowy_web:${APPFLOWY_WEB_VERSION:-latest}
+    container_name: appflowy-web
+    restart: unless-stopped
+    depends_on:
+      - appflowy-cloud
+    environment:
+      - APPFLOWY_BASE_URL=${APPFLOWY_PUBLIC_BASE_URL}
+      - APPFLOWY_GOTRUE_BASE_URL=${APPFLOWY_PUBLIC_GOTRUE_URL}
+      - APPFLOWY_WS_BASE_URL=${APPFLOWY_PUBLIC_WS_URL}
+    networks:
+      - homelab
+      - homelab_proxy
+    labels:
+      - "traefik.enable=true"
+      - "traefik.docker.network=homelab_proxy"
+      - "traefik.http.routers.appflowy-web.rule=Host(`${APPFLOWY_DOMAIN}`)"
+      - "traefik.http.routers.appflowy-web.entrypoints=websecure"
+      - "traefik.http.routers.appflowy-web.tls.certresolver=cloudflare"
+      - "traefik.http.services.appflowy-web.loadbalancer.server.port=80"
+
+  appflowy-admin:
+    image: appflowyinc/admin_frontend:${APPFLOWY_ADMIN_FRONTEND_VERSION:-latest}
+    container_name: appflowy-admin
+    restart: unless-stopped
+    depends_on:
+      appflowy-gotrue:
+        condition: service_healthy
+      appflowy-cloud:
+        condition: service_started
+    environment:
+      - APPFLOWY_BASE_URL=${APPFLOWY_PUBLIC_BASE_URL}
+      - APPFLOWY_GOTRUE_BASE_URL=${APPFLOWY_PUBLIC_GOTRUE_URL}
+      - ADMIN_FRONTEND_PATH_PREFIX=${ADMIN_FRONTEND_PATH_PREFIX}
+      - ADMIN_FRONTEND_GOTRUE_URL=http://appflowy-gotrue:9999
+      - ADMIN_FRONTEND_APPFLOWY_CLOUD_URL=http://appflowy-cloud:8000
+      - ADMIN_FRONTEND_REDIS_URL=redis://appflowy-redis:6379
+    networks:
+      - homelab
+      - homelab_proxy
+    labels:
+      - "traefik.enable=true"
+      - "traefik.docker.network=homelab_proxy"
+      - "traefik.http.routers.appflowy-admin.rule=Host(`${APPFLOWY_DOMAIN}`) && PathPrefix(`/console`)"
+      - "traefik.http.routers.appflowy-admin.entrypoints=websecure"
+      - "traefik.http.routers.appflowy-admin.tls.certresolver=cloudflare"
+      - "traefik.http.services.appflowy-admin.loadbalancer.server.port=3000"
+
+  # ----------------------------
+  # UTILITIES
   # ----------------------------
 
   flaresolverr:
@@ -557,8 +809,11 @@ services:
     restart: unless-stopped
     networks:
       - homelab
+  # ----------------------------
+  # NETWORK & ADMIN SERVICES
+  # ----------------------------
 
-  # share files with Windows
+  # SMB file sharing for Windows clients
   samba:
     container_name: samba
     image: dperson/samba
@@ -641,7 +896,9 @@ services:
       - "traefik.http.routers.portainer.middlewares=authelia@docker"
       - "traefik.http.services.portainer.loadbalancer.server.port=9000"
 
-  # backup
+  # ----------------------------
+  # BACKUP & RECOVERY
+  # ----------------------------
   duplicati:
     image: lscr.io/linuxserver/duplicati:latest
     container_name: duplicati
@@ -665,6 +922,10 @@ services:
       - "traefik.http.routers.duplicati.tls.certresolver=cloudflare"
       - "traefik.http.routers.duplicati.middlewares=authelia@docker"
       - "traefik.http.services.duplicati.loadbalancer.server.port=8200"
+
+  # ----------------------------
+  # INGRESS & SECURITY
+  # ----------------------------
 
   # Reverse proxy, dashboard & certificates
   traefik:
@@ -735,7 +996,7 @@ services:
       - ./config/traefik/letsencrypt:/letsencrypt
       - ./config/traefik/certs:/output
 
-  # Authentification
+  # Authentication
   authelia:
     image: ghcr.io/authelia/authelia:latest
     container_name: authelia


### PR DESCRIPTION
## Summary
- add the AppFlowy Cloud services (Postgres, Redis, Minio, GoTrue, backend, worker, web, admin console) to docker-compose with Traefik routing and clearer section headers
- extend .env.example with AppFlowy configuration placeholders and reorganized comments for existing sections

## Testing
- `docker compose config` *(fails: docker not installed in CI environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d2594a81188328b306a8483de067aa