### PR TITLE
Add pgAdmin service for PostgreSQL management

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,10 @@ CERT=/home/antoine/home-server/config/swag/etc/letsencrypt/archive/antoineglacet
 POSTGRES_HOST=postgres
 POSTGRES_PORT=5432
 
+# pgAdmin Settings
+PGADMIN_DEFAULT_EMAIL=admin@example.com
+PGADMIN_DEFAULT_PASSWORD=change_me_pgadmin_password
+
 # ----------------------------
 # HOME AUTOMATION
 # ----------------------------

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ All services now live in one `docker-compose.yml`. Logical groupings still help 
 | Smart home & Zigbee | Host LAN for discovery, `homelab` for MQTT, `homelab_proxy` for Zigbee UI | Automations, device telemetry, and Zigbee radio access. | `home-assistant`, `mqtt`, `zigbee2mqtt` |
 | Media acquisition & library | `homelab` for internal traffic, `homelab_proxy` for UIs, host for Plex | VPN-protected downloads, request management, and playback. | `nordlynx`, `transmission`, `prowlarr`, `sonarr`, `radarr`, `bazarr`, `readarr`, `plex`, `overseerr`, `calibre-web-automated` |
 | Monitoring & observability | `homelab` for metrics, `homelab_proxy` for dashboards, host exporters | Metrics, uptime checks, and capacity visibility. | `prometheus`, `grafana`, `uptime-kuma`, `cadvisor`, `glances`, `node_exporter` |
-| Edge & utilities | `homelab` + `homelab_proxy` | Reverse proxy, SSO, DNS, backups, syncing, and helper tools. | `traefik`, `authelia`, `authentik`, `homepage`, `adguard`, `portainer`, `duplicati`, `ddclient`, `samba`, `syncthing`, `flaresolverr`, `autoheal` |
+| Edge & utilities | `homelab` + `homelab_proxy` | Reverse proxy, SSO, DNS, backups, syncing, and helper tools. | `traefik`, `authelia`, `authentik`, `homepage`, `adguard`, `portainer`, `pgadmin`, `duplicati`, `ddclient`, `samba`, `syncthing`, `flaresolverr`, `autoheal` |
 
 ## Repo Layout
 
@@ -54,6 +54,7 @@ Helper scripts in the repo still reference the old multi-stack layout. Update or
 ### Environment & Secrets
 
 - Maintain a `.env` next to `docker-compose.yml` with UID/GID, timezone, storage paths, VPN keys, Cloudflare token, MQTT credentials, Authelia/Authentik secrets, and Zigbee adaptor path. (Check the compose file for the full list of expected variables.)
+- pgAdmin credentials live in `PGADMIN_DEFAULT_EMAIL` and `PGADMIN_DEFAULT_PASSWORD` so the web UI is ready for first sign-in.
 - Run Compose commands from the repo root so the relative `config/` mounts resolve correctly.
 - Per-service configuration lives under `config/` and is bind-mounted back into containers.
 

--- a/config/homepage/services.yaml
+++ b/config/homepage/services.yaml
@@ -66,6 +66,10 @@
         icon: portainer
         href: https://portainer.antoineglacet.com
         description: Container management UI
+    - pgAdmin:
+        icon: pgadmin
+        href: https://pgadmin.antoineglacet.com
+        description: PostgreSQL administration
     - Grafana:
         icon: grafana
         href: https://grafana.antoineglacet.com

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -532,6 +532,26 @@ services:
     networks:
       - homelab
 
+  pgadmin:
+    restart: unless-stopped
+    image: dpage/pgadmin4:latest
+    environment:
+      - PGADMIN_DEFAULT_EMAIL=${PGADMIN_DEFAULT_EMAIL}
+      - PGADMIN_DEFAULT_PASSWORD=${PGADMIN_DEFAULT_PASSWORD}
+    volumes:
+      - pgadmin_data:/var/lib/pgadmin
+    networks:
+      - homelab
+      - homelab_proxy
+    labels:
+      - "traefik.enable=true"
+      - "traefik.docker.network=homelab_proxy"
+      - "traefik.http.routers.pgadmin.rule=Host(`pgadmin.${TRAEFIK_DOMAIN}`)"
+      - "traefik.http.routers.pgadmin.entrypoints=websecure"
+      - "traefik.http.routers.pgadmin.tls.certresolver=cloudflare"
+      - "traefik.http.routers.pgadmin.middlewares=authelia@docker"
+      - "traefik.http.services.pgadmin.loadbalancer.server.port=80"
+
   redis:
     restart: on-failure
     image: redis
@@ -1096,3 +1116,4 @@ volumes:
   postgres_data:
   minio_data:
   authentik_redis_data:
+  pgadmin_data:


### PR DESCRIPTION
## Summary
- add a pgAdmin container with Traefik routing and persistent storage for the PostgreSQL stack
- surface the pgAdmin default credentials in the environment template and documentation
- link the new UI from the homepage dashboard for quick access

## Testing
- not run (not run)


------
https://chatgpt.com/codex/tasks/task_b_68d785a621b0832893b0d9b986aa0647