### PR TITLE
Add Grafana Loki log aggregation stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,14 @@ config/portainer/backups/
 # Homepage dashboard
 !config/homepage/*.yaml
 
+# Loki & log aggregation configs
+!config/loki/
+!config/loki/**/*.yaml
+!config/loki/**/*.yml
+!config/promtail/
+!config/promtail/**/*.yaml
+!config/promtail/**/*.yml
+
 # Traefik
 !config/traefik/
 !config/traefik/**/*.yaml

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ All services now live in one `docker-compose.yml`. Logical groupings still help 
 | --- | --- | --- | --- |
 | Smart home & Zigbee | Host LAN for discovery, `homelab` for MQTT, `homelab_proxy` for Zigbee UI | Automations, device telemetry, and Zigbee radio access. | `home-assistant`, `mqtt`, `zigbee2mqtt` |
 | Media acquisition & library | `homelab` for internal traffic, `homelab_proxy` for UIs, host for Plex | VPN-protected downloads, request management, and playback. | `nordlynx`, `transmission`, `prowlarr`, `sonarr`, `radarr`, `bazarr`, `readarr`, `plex`, `overseerr`, `calibre-web-automated` |
-| Monitoring & observability | `homelab` for metrics, `homelab_proxy` for dashboards, host exporters | Metrics, uptime checks, and capacity visibility. | `prometheus`, `grafana`, `uptime-kuma`, `cadvisor`, `glances`, `node_exporter` |
+| Monitoring & observability | `homelab` for metrics, `homelab_proxy` for dashboards, host exporters | Metrics, uptime checks, and capacity visibility. | `prometheus`, `grafana`, `loki`, `promtail`, `uptime-kuma`, `cadvisor`, `glances`, `node_exporter` |
 | Edge & utilities | `homelab` + `homelab_proxy` | Reverse proxy, SSO, DNS, backups, syncing, and helper tools. | `traefik`, `authelia`, `authentik`, `homepage`, `adguard`, `portainer`, `pgadmin`, `duplicati`, `ddclient`, `samba`, `syncthing`, `flaresolverr`, `autoheal` |
 
 ## Repo Layout
@@ -26,7 +26,9 @@ home-server
 │   ├── ddclient/          # Dynamic DNS updater config
 │   ├── homeassistant/     # Home Assistant state & automations
 │   ├── homepage/          # Dashboard definition
+│   ├── loki/              # Loki index & retention settings
 │   ├── mosquitto/         # MQTT broker settings
+│   ├── promtail/          # Promtail scrape targets and pipelines
 │   ├── traefik/           # Reverse proxy configuration & cert dumps
 │   └── zigbee2mqtt/       # Zigbee bridge configuration
 ├── pull-all.sh            # legacy helper (multi-stack version, kept for ref)
@@ -105,6 +107,7 @@ flowchart LR
 ### Monitoring & Self-Healing
 
 - Prometheus scrapes `node_exporter` (host metrics) and `cadvisor` (container metrics); Grafana dashboards visualize both.
+- Grafana Loki ingests container logs with Promtail tailing the Docker socket, so every service shares a centralised log history.
 - `uptime-kuma` keeps an eye on web UIs and external endpoints.
 - `autoheal` watches healthchecks and restarts unhealthy containers automatically.
 

--- a/config/homepage/services.yaml
+++ b/config/homepage/services.yaml
@@ -74,6 +74,10 @@
         icon: grafana
         href: https://grafana.antoineglacet.com
         description: Metrics dashboards
+    - Grafana Loki:
+        icon: grafana
+        href: https://loki.antoineglacet.com
+        description: Centralised log aggregation
     - Syncthing:
         icon: syncthing
         href: https://syncthing.antoineglacet.com

--- a/config/loki/local-config.yaml
+++ b/config/loki/local-config.yaml
@@ -1,0 +1,49 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9096
+
+common:
+  instance_addr: 127.0.0.1
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  ring:
+    kvstore:
+      store: inmemory
+  replication_factor: 1
+
+schema_config:
+  configs:
+    - from: 2023-01-01
+      store: boltdb-shipper
+      object_store: filesystem
+      schema: v11
+      index:
+        prefix: index_
+        period: 24h
+
+storage_config:
+  filesystem:
+    directory: /loki/chunks
+  boltdb_shipper:
+    active_index_directory: /loki/index
+    cache_location: /loki/boltdb-cache
+    shared_store: filesystem
+
+ruler:
+  storage:
+    type: local
+    local:
+      directory: /loki/rules
+  rule_path: /loki/rules-temp
+  alertmanager_url: http://localhost:9093
+  ring:
+    kvstore:
+      store: inmemory
+
+analytics:
+  reporting_enabled: false

--- a/config/promtail/config.yaml
+++ b/config/promtail/config.yaml
@@ -1,0 +1,33 @@
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+    batchwait: 1s
+    batchsize: 1048576
+
+scrape_configs:
+  - job_name: docker
+    docker_sd_configs:
+      - host: unix:///var/run/docker.sock
+        refresh_interval: 5s
+    relabel_configs:
+      - source_labels: ['__meta_docker_container_name']
+        regex: '/(.*)'
+        target_label: container
+      - source_labels: ['__meta_docker_container_label_com_docker_compose_service']
+        target_label: compose_service
+      - source_labels: ['__meta_docker_container_label_com_docker_compose_project']
+        target_label: compose_project
+      - source_labels: ['__meta_docker_container_label_traefik_http_routers']
+        target_label: traefik_router
+      - source_labels: ['__meta_docker_container_log_stream']
+        target_label: log_stream
+      - source_labels: ['__meta_docker_container_label_org_label_schema_group']
+        target_label: stack
+    pipeline_stages:
+      - docker: {}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -170,6 +170,41 @@ services:
       - "traefik.http.routers.grafana.middlewares=authelia@docker"
       - "traefik.http.services.grafana.loadbalancer.server.port=3000"
 
+  loki:
+    image: grafana/loki:2.9.4
+    container_name: loki
+    command: -config.file=/etc/loki/local-config.yaml
+    volumes:
+      - ./config/loki:/etc/loki
+      - ./data/loki:/loki
+    restart: unless-stopped
+    networks:
+      - homelab
+      - homelab_proxy
+    labels:
+      - "traefik.enable=true"
+      - "traefik.docker.network=homelab_proxy"
+      - "traefik.http.routers.loki.rule=Host(`loki.${TRAEFIK_DOMAIN}`)"
+      - "traefik.http.routers.loki.entrypoints=websecure"
+      - "traefik.http.routers.loki.tls.certresolver=cloudflare"
+      - "traefik.http.routers.loki.middlewares=authelia@docker"
+      - "traefik.http.services.loki.loadbalancer.server.port=3100"
+
+  promtail:
+    image: grafana/promtail:2.9.4
+    container_name: promtail
+    command: -config.file=/etc/promtail/config.yaml
+    volumes:
+      - ./config/promtail:/etc/promtail
+      - ./data/promtail:/tmp
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    restart: unless-stopped
+    depends_on:
+      - loki
+    networks:
+      - homelab
+
   glances:
     image: nicolargo/glances:latest-full
     container_name: glances


### PR DESCRIPTION
## Summary
- add Grafana Loki and Promtail services to docker-compose, exposing Loki via Traefik with Authelia protection
- capture Loki and Promtail configuration in version control and surface Loki on the Homepage dashboard
- document the new log aggregation stack in the README

## Testing
- not run (docker CLI is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_b_68d7e55751c48328b8e76c5f4aa43d2e